### PR TITLE
add the leather pride and bear pride flags to the stripe generator

### DIFF
--- a/web/src/components/rainbow/Rainbow.js
+++ b/web/src/components/rainbow/Rainbow.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { Stripe, SubWrapper, Wrapper } from './elements'
 
-export const max = 8
+export const max = 37
 
 export default ({ stripes, children, ...other }) => {
   const streeps = useMemo(() => new Array(max).fill(undefined), [max])

--- a/web/src/helpers/useRainbow.js
+++ b/web/src/helpers/useRainbow.js
@@ -1,21 +1,51 @@
 import React, { createContext, useContext, useState } from 'react'
 import { toPastel } from './colours'
 
+// helpers for representing flags that have different sized stripes
+const sizedStripe = (color, size) => {
+  return new Array(size).fill(color)
+}
+const flatten = (arr) => {
+  return arr.reduce((accum, items)=>{
+    return accum.concat(items);
+  }, [])
+}
+// helper to make all the flags have a similar number of stripes
+const makeSimilarLengths = (longestFlag) => {
+  return (stripes) => {
+    const multiplier = Math.floor(longestFlag / stripes.length)
+    if(multiplier > 1) {
+      return flatten(stripes.map(stripe => sizedStripe(stripe, multiplier)))
+    } else {
+      return stripes
+    }
+  }
+}
+
 // stolen from flag
 const gayStripes = ['#FF5D7D', '#FF764E', '#FFC144', '#88DF8E', '#00CCF2', '#B278D3']
 const transStripes = ['#55CDFC', '#F7A8B8', '#DDD', '#F7A8B8', '#55CDFC'].map(toPastel)
-const biStripes = ['#D9006F', '#D9006F', '#744D98', '#0033AB', '#0033AB'].map(toPastel)
+const biStripes = flatten([sizedStripe('#D9006F',2), '#744D98', sizedStripe('#0033AB',2)]).map(toPastel)
 const aceStripes = ['#000000', '#A3A3A3', '#DDD', '#810082'].map(toPastel)
 const panStripes = ['#FF008E', '#FFD800', '#00B3FF'].map(toPastel)
+const [ blackStripe, blueStripe, redStripe, whiteStripe ] = [
+  sizedStripe('#000000', 4), sizedStripe('#0000c0', 4), '#fb0006', sizedStripe('#EEE', 4)
+]
+const leatherStripes = flatten([
+  blackStripe, blueStripe, redStripe, blackStripe, blueStripe,
+  whiteStripe, blueStripe, blackStripe, blueStripe, blackStripe
+]).map(toPastel)
+const bearStripes = ["#4e2801", "#ca4e05", "#fdd951", "#fde2ac", "#EEE", "#424242", "#000000"]
+
 // pastel enough
 const lesbianStripes = ['#B60063', '#C84896', '#E253AB', '#DDD', '#F0A7D2', '#D73F4F', '#990200']
 
 const allStripes = [
   gayStripes,
-  ...[transStripes, panStripes, biStripes, aceStripes, lesbianStripes].sort(
+  ...[transStripes, panStripes, biStripes, aceStripes, lesbianStripes, leatherStripes, bearStripes].sort(
     () => 0.5 - Math.random()
   )
-]
+].map(makeSimilarLengths(leatherStripes.length))
 
 const useStripesInCtx = () => {
   const [stripes, setStripes] = useState(0)


### PR DESCRIPTION
slight refactor in here. Sorry about that.
In order to get the scale right for the red stripe in the leather pride flag, had to use a lot of duplicate stripes, the ending flag is 37 stripes....
To accomplish this easily I added a `sizedStripe` function which takes a color and returns multiple copies. Because of this, the resulting array has to be `flatten`ed. 
Because of the huge difference between a 37 stripe flag and a 3 stripe flag like the Pan flag, I added a `makeSimilarLengths` method to multiply the stripes so the Pan ends up getting defined with 36 stripes, this makes the animations look good no matter what. Although the animation style loses the stripes sort of growing and shrinking and now it is mostly just fading between.

<img width="376" alt="Screen Shot 2019-06-24 at 1 41 13 PM" src="https://user-images.githubusercontent.com/333260/60039891-c4ea0a80-9685-11e9-83b9-efb8c1681ecd.png">
<img width="379" alt="Screen Shot 2019-06-24 at 1 41 02 PM" src="https://user-images.githubusercontent.com/333260/60039892-c582a100-9685-11e9-8c79-bf9751e85e7c.png">
